### PR TITLE
Changed mv calls to cp and cp -r, and added a containerfile.

### DIFF
--- a/CRISPRCasFinder.pl
+++ b/CRISPRCasFinder.pl
@@ -720,7 +720,7 @@ while($seq = $seqIO->next_seq()){  # DC - replace 'next_seq' by 'next_seq()'
   	#create a directory GFF and move all GFFs to this directory
   	#my $directoryGFFfiles = $ResultDir."/GFF";  # Directory for GFFs
   	#mkdir $directoryGFFfiles unless -d $directoryGFFfiles;
-	if(-d $ResultDir."/GFF"){ makesystemcall("mv $gffFilename $ResultDir/GFF "); }
+	if(-d $ResultDir."/GFF"){ makesystemcall("cp $gffFilename $ResultDir/GFF "); }
 
   	#Move CRISPRproperties, DRs and Spacers to specific directories
   	my $input_spacers = $ResultDir."/".$RefSeq."/Spacers_"; # Path to the Spacers files
@@ -735,14 +735,14 @@ while($seq = $seqIO->next_seq()){  # DC - replace 'next_seq' by 'next_seq()'
   	mkdir $directoryCRISPRproperties unless -d $directoryCRISPRproperties;
   
   	if ( (-e $input_spacers."1") and (-e $input_drs."1") ){
-    		makesystemcall("mv $input_spacers* $directorySpacers");
-    		makesystemcall("mv $input_drs* $directoryDRs");
-    		makesystemcall("mv $input_properties* $directoryCRISPRproperties");
+    		makesystemcall("cp -r $input_spacers* $directorySpacers");
+    		makesystemcall("cp -r $input_drs* $directoryDRs");
+    		makesystemcall("cp -r $input_properties* $directoryCRISPRproperties");
  	}
 
   	if(-e $input_properties."_CRISPRs"){
     		my $reportProperties = $input_properties."_CRISPRs";
-    		makesystemcall("mv $reportProperties $directoryCRISPRproperties");
+    		makesystemcall("cp -r $reportProperties $directoryCRISPRproperties");
   	}
 
   	my $directoryProperties = $ResultDir."/".$RefSeq;
@@ -752,13 +752,13 @@ while($seq = $seqIO->next_seq()){  # DC - replace 'next_seq' by 'next_seq()'
 		$newProperties = $ResultDir."/CRISPRFinderProperties/".$RefSeq."_properties";
 	} #NV
   	if(-d $directoryProperties){
-    		makesystemcall("mv $directoryProperties $newProperties"); # rename properties for each sequence
+    		makesystemcall("cp -r $directoryProperties $newProperties"); # rename properties for each sequence
   	}
 
   	#create a directory Properties and move all sequenceProperties directories in one
   	#my $directoryPropertiesFinal = $ResultDir."/CRISPRFinderProperties";  # Directory for Properties
   	#mkdir $directoryPropertiesFinal unless -d $directoryPropertiesFinal;
-  	#makesystemcall("mv $newProperties $directoryPropertiesFinal");
+  	#makesystemcall("cp -r $newProperties $directoryPropertiesFinal");
 
   	# End Move properties, DRs and Spacers
   
@@ -815,7 +815,7 @@ while($seq = $seqIO->next_seq()){  # DC - replace 'next_seq' by 'next_seq()'
   	my $analyzedSequences = $ResultDir."/analyzedSequences";  # Directory for FASTAs
   	mkdir $analyzedSequences unless -d $analyzedSequences;
   	if(-e $inputfile){
-    		makesystemcall("mv $inputfile $analyzedSequences");
+    		makesystemcall("cp -r $inputfile $analyzedSequences");
   	}
  } #NV end condition for mss option  
 } # end while (my $seq = $seqIO->next_seq)
@@ -831,14 +831,14 @@ print JSONRES $jsonLineRes;
 close (JSONRES);
 # move JSONRES in ResultDir
 if(-e $jsonResult){
-  makesystemcall("mv $jsonResult $ResultDir");
+  makesystemcall("cp -r $jsonResult $ResultDir");
 }
 
 #create a directory JSONfiles and move all JSONs to this directory
 #my $directoryJSONfiles = $ResultDir."/JSON_files";  # Directory for JSONs
 #mkdir $directoryJSONfiles unless -d $directoryJSONfiles;
 #if(-e $ResultDir."/result.json"){
-#  makesystemcall("mv $ResultDir/*.json $directoryJSONfiles");
+#  makesystemcall("cp -r $ResultDir/*.json $directoryJSONfiles");
 #}
 
 #fullReport
@@ -877,10 +877,10 @@ if(-e $clustersResults){ makesystemcall("cp $clustersResults $clustersResultsX")
 my $directoryTSVfiles = $ResultDir."/TSV";  # Directory for TSVs
 mkdir $directoryTSVfiles unless -d $directoryTSVfiles;
 if(-e "$ResultDir/Crisprs_REPORT.tsv"){
-  makesystemcall("mv $ResultDir/*.tsv $directoryTSVfiles");
+  makesystemcall("cp $ResultDir/*.tsv $directoryTSVfiles");
 }
 if(-e "$ResultDir/Crisprs_REPORT.xls"){
-  makesystemcall("mv $ResultDir/*.xls $directoryTSVfiles");
+  makesystemcall("cp $ResultDir/*.xls $directoryTSVfiles");
 }
 
 #create a directory FASTAfiles and move all rawFASTAs to this directory
@@ -895,21 +895,21 @@ mkdir $directoryFASTAfiles unless -d $directoryFASTAfiles;
 
 my $analyzedSequences2 = $ResultDir."/analyzedSequences";  # Directory for analyzed FASTAs
 if(-d $analyzedSequences2){
-  makesystemcall("mv $analyzedSequences2 $directoryFASTAfiles");
+  makesystemcall("cp -r $analyzedSequences2 $directoryFASTAfiles");
 }
 
 #create a directory Properties and move all sequenceProperties directories in one
 my $directoryProperties = $ResultDir."/CRISPRFinderProperties";  # Directory for Properties
 #mkdir $directoryProperties unless -d $directoryProperties; #before NV
 #if(-e "$ResultDir/*_properties"){
-  #makesystemcall("mv $ResultDir/*_properties $directoryProperties"); #before NV
+  #makesystemcall("cp -r $ResultDir/*_properties $directoryProperties"); #before NV
 #}
 
 #create a directory GFF and move all GFFs to this directory
 #my $directoryGFFfiles = $ResultDir."/GFF";  # Directory for GFFs # DC
 #mkdir $directoryGFFfiles unless -d $directoryGFFfiles; # DC
 #if(-e "$ResultDir/*.gff"){
-  #makesystemcall("mv $ResultDir/*.gff $directoryGFFfiles"); #before NV
+  #makesystemcall("cp -r $ResultDir/*.gff $directoryGFFfiles"); #before NV
   #makesystemcall("find $ResultDir -name *.gff -exec mv {} $directoryGFFfiles \\;"); #NV DC
 #}
 
@@ -990,8 +990,8 @@ if($logOption){
   unless(-d $directoryLog){ mkdir $directoryLog or die "$0: I can not create the folder $directoryLog: $!\n" }
 
   if ( (-e $logfile) and (-e $logSeq) ){
-    makesystemcall("mv $logfile $directoryLog");
-    makesystemcall("mv $logSeq $directoryLog");
+    makesystemcall("cp $logfile $directoryLog");
+    makesystemcall("cp $logSeq $directoryLog");
   }
 }
 
@@ -1000,7 +1000,7 @@ if($html){
   my $directoryViz = $ResultDir."/Visualization"; # directory  to store basic Visualization files
   unless(-d $directoryViz){ mkdir $directoryViz or die "$0: I can not create the folder $directoryViz: $!\n" }
 
-  makesystemcall("mv $htmlFile $directoryViz");
+  makesystemcall("cp $htmlFile $directoryViz");
 
   if(-e "crispr.css"){
   	makesystemcall("cp crispr.css $directoryViz");
@@ -1668,7 +1668,7 @@ sub casFinder
 
     	system ("cp $gff $tmpGFFprokka"); 
 
-	makesystemcall("mv $tmpGFFprokka $ResultDir/GFF");
+	makesystemcall("cp -r $tmpGFFprokka $ResultDir/GFF");
     }
 
     ## get the summary report which has been created by casfinder
@@ -2223,7 +2223,7 @@ sub casFinder
 		my $directoryProkka = $ResultDir."/Prokka";  # Directory for Prokka
 		mkdir $directoryProkka unless -d $directoryProkka;
 		if(-d $repProkka and -e $repProkka and -e $directoryProkka){
-			makesystemcall("mv $repProkka $directoryProkka");
+			makesystemcall("cp -r $repProkka $directoryProkka");
 	        }
 	    }
 	    else{
@@ -2231,7 +2231,7 @@ sub casFinder
 		mkdir $directoryProdigal unless -d $directoryProdigal;
 
 		if(-d $repProkka){
-			makesystemcall("mv $repProkka $directoryProdigal");
+			makesystemcall("cp -r $repProkka $directoryProdigal");
 		}
 	    }
 	}
@@ -2239,7 +2239,7 @@ sub casFinder
 	my $directoryCasfinder = $ResultDir."/CasFinder";  # Directory for CasFinder
 	mkdir $directoryCasfinder unless -d $directoryCasfinder;
 	if(-d $casDir){
-	makesystemcall("mv $casDir $directoryCasfinder");
+	makesystemcall("cp -r $casDir $directoryCasfinder");
 	}
   ##}
 
@@ -2298,7 +2298,7 @@ sub fullReport{
 	  close (CRISPR);
 	  close (FULL);
   }
-  makesystemcall("mv $fullReport $resultsCRISPRs"); # Move fullReport file into CRISPRs_report
+  makesystemcall("cp $fullReport $resultsCRISPRs"); # Move fullReport file into CRISPRs_report
   #makesystemcall("rm -f $allCas"); # remove $allCas
   return $fullReport;
 }
@@ -3307,7 +3307,7 @@ sub crisprAnalysis
     #### Move created alignment files into $directory
       #my ($hourMv,$minMv,$secMv) = Now();
       my $fastaStar = $spacerFasta."*";
-      my $ret = system("mv $fastaStar $directory");
+      my $ret = system("cp -r $fastaStar $directory");
       #print "Moving files $fastaStar in $directory (return type: $ret)\n";
       
       if($logOption){	
@@ -3315,7 +3315,7 @@ sub crisprAnalysis
       }
 
       $fastaStar = $drFasta."*";
-      $ret = system("mv $fastaStar $directory");
+      $ret = system("cp -r $fastaStar $directory");
       #print "Moving files $fastaStar in $directory (return type: $ret)\n";
 
       if($logOption){

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,95 @@
+FROM ubuntu:20.04
+
+LABEL software="CRISPRCasFinder"
+LABEL software.version="4.3.2"
+LABEL description="CRISPRCasFinder is an updated, improved, and integrated version of CRISPRFinder and CasFinder."
+LABEL website="https://github.com/dcouvin/CRISPRCasFinder/"
+LABEL license="https://github.com/dcouvin/CRISPRCasFinder/blob/master/COPYRIGHT"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        build-essential \
+        wget \
+        unzip \
+        curl \
+        git \
+        default-jre \
+        python \
+        parallel \
+        cpanminus \
+        hmmer \
+        emboss \
+        emboss-lib \
+        ncbi-blast+ \
+        bioperl \
+        bioperl-run \
+        python3-biopython \
+        libdatetime-perl \
+        libxml-simple-perl \
+        libdigest-md5-perl \
+        prodigal \
+        original-awk \
+        dateutils \
+        procps \
+        pcregrep \
+        sed \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+# perl deps
+RUN cpanm -n Unix::Sysexits
+RUN cpanm -n Try::Tiny
+RUN cpanm -n Test::Most
+RUN cpanm -n JSON::Parse
+RUN cpanm -n Class::Struct
+RUN cpanm -n Bio::DB::Fasta
+RUN cpanm -n File::Copy
+RUN cpanm -n Bio::Seq Bio::SeqIO
+RUN cpanm -n Bio::Tools::Run::Alignment::Muscle
+
+WORKDIR /opt
+
+COPY . CRISPRCasFinder
+
+RUN mkdir CRISPRCasFinder/src CRISPRCasFinder/bin && \
+    ln -s /opt/CRISPRCasFinder/CRISPRCasFinder.pl /usr/local/bin/
+
+# get muscle v.5.1.0
+WORKDIR /opt/CRISPRCasFinder/src
+RUN wget -q https://github.com/rcedgar/muscle/releases/download/5.1.0/muscle5.1.linux_intel64 && \
+    cp muscle5.1.linux_intel64 /usr/local/bin/muscle && \
+    rm muscle5.1.linux_intel64
+
+WORKDIR /usr/local/bin
+RUN chmod +x /usr/local/bin/*
+
+# build vmatch
+ENV vmatchVer="2.3.0"
+WORKDIR /opt/CRISPRCasFinder/src
+RUN wget -q http://vmatch.de/distributions/vmatch-${vmatchVer}-Linux_x86_64-64bit.tar.gz && \
+    tar -zxf vmatch-${vmatchVer}-Linux_x86_64-64bit.tar.gz && \
+    gcc -Wall -Werror -fPIC -O3 -shared vmatch-${vmatchVer}-Linux_x86_64-64bit/SELECT/sel392.c -o /opt/CRISPRCasFinder/sel392v2.so && \
+    cp vmatch-${vmatchVer}-Linux_x86_64-64bit/vmatch /usr/local/bin/vmatch && \
+    cp vmatch-${vmatchVer}-Linux_x86_64-64bit/mkvtree /usr/local/bin/mkvtree && \
+    cp vmatch-${vmatchVer}-Linux_x86_64-64bit/vsubseqselect /usr/local/bin/vsubseqselect && \
+    rm -rf vmatch-${vmatchVer}-Linux_x86_64-64bit*
+
+# get MacSyFinder
+ENV macsyfinderVer="2.0"
+WORKDIR /opt
+
+RUN wget -O macsyfinder-${macsyfinderVer}.tar.gz -q https://github.com/gem-pasteur/macsyfinder/archive/refs/tags/v${macsyfinderVer}.tar.gz && \
+    tar -xzf macsyfinder-${macsyfinderVer}.tar.gz && \
+    rm macsyfinder-${macsyfinderVer}.tar.gz && \
+    ln -s /opt/macsyfinder-${macsyfinderVer}/bin/macsyfinder /usr/local/bin/
+
+ENV MACSY_HOME=/opt/macsyfinder-${macsyfinderVer}/
+
+ENV LC_ALL=C
+
+RUN mkdir /data
+WORKDIR /data
+
+CMD ["/bin/bash", "-c"]


### PR DESCRIPTION
The mv calls are causing issues on shared filesystems.

See reports:

- https://github.com/dcouvin/CRISPRCasFinder/issues/35
- https://github.com/EBI-Metagenomics/mobilome-annotation-pipeline/issues/37

This patch is not an ideal solution; the proper approach would be to avoid moving or copying files and instead generate them directly in their final folder. However, I don't have the capacity to address this or the necessary Perl knowledge.

The container is compatible with Docker and Singularity.